### PR TITLE
Add build test with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: swift
+osx_image: xcode10.2
+before_script:
+  - gem install xcpretty
+script:
+  - set -o pipefail
+  - xcodebuild -workspace Transportation_PLUS.xcodeproj/project.xcworkspace -scheme Transportation_PLUS -destination 'platform=iOS Simulator,name=iPhone 8,OS=11.3' build | xcpretty --test --color


### PR DESCRIPTION
To make sure the app can be built when each code changes, add the build
test with the Travis CI service.

See also:
 - https://docs.travis-ci.com/user/languages/objective-c
 - https://github.com/rootstrap/ios-base