### PR TITLE
Add Travis CI badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # TransportPlus
+
+[![Build Status](https://travis-ci.com/NullRa/TransportPlus.svg?branch=master)](https://travis-ci.com/NullRa/TransportPlus)
+
 simple beginning


### PR DESCRIPTION
To check the master branch build status, add the Travis CI badge to
readme.

See also: https://docs.travis-ci.com/user/status-images